### PR TITLE
Update aimp_control_plugin.iss

### DIFF
--- a/inno_setup_data/aimp_control_plugin.iss
+++ b/inno_setup_data/aimp_control_plugin.iss
@@ -29,7 +29,7 @@ OutputBaseFilename=aimp_control_plugin-{#FileVerStr}-setup
 ; (To generate a new GUID, click Tools | Generate GUID inside the IDE.)
 AppId={{F171581D-00CD-4E77-8982-B1B68FDCAAFA}
 AppPublisher=Alexey Ivanov
-AppCopyright=Copyright © 2014 Alexey Ivanov
+AppCopyright=Copyright Â© 2014 Alexey Ivanov
 AppPublisherURL=https://github.com/a0ivanov/aimp-control-plugin
 AppSupportURL=http://code.google.com/p/aimp-control-plugin/w/list
 AppUpdatesURL=https://github.com/a0ivanov/aimp-control-plugin/releases/latest
@@ -51,6 +51,7 @@ AppendDefaultDirName=true
 ; Language name is used on Donation page as {language} constant.
 Name: en; MessagesFile: inno_setup_data\English.isl; LicenseFile: Lisense-English.txt;
 Name: ru; MessagesFile: inno_setup_data\Russian.isl; LicenseFile: Lisense-Russian.txt;
+Name: cs; MessagesFile: inno_setup_data\Czech.isl;   LicenseFile: Lisense-English.txt;
 
 [Files]
 Source: "{#SrcApp}"; DestDir: "{app}"; Flags: ignoreversion


### PR DESCRIPTION
Fix missing Czech l10n in Settings Manager. Czech license is not translated, because I didn't find official Czech translation. So it uses english license.
